### PR TITLE
improve search speed by using redis mget

### DIFF
--- a/kvs/bolt.go
+++ b/kvs/bolt.go
@@ -73,6 +73,7 @@ func (b *BoltDB) GetKey(val uint) ([]byte, error) {
 	return b.get(vkBoltBucketName, ToBytes(val))
 }
 
+// GetKeys wraps multiple calls GetKey
 func (b *BoltDB) GetKeys(vals []uint) ([][]byte, error) {
 	ret := make([][]byte, len(vals))
 	for i, val := range vals {

--- a/kvs/bolt.go
+++ b/kvs/bolt.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"fmt"
+
 	"github.com/boltdb/bolt"
 )
 
@@ -70,6 +71,18 @@ func (b *BoltDB) get(boltBucketName []byte, key []byte) ([]byte, error) {
 
 func (b *BoltDB) GetKey(val uint) ([]byte, error) {
 	return b.get(vkBoltBucketName, ToBytes(val))
+}
+
+func (b *BoltDB) GetKeys(vals []uint) ([][]byte, error) {
+	ret := make([][]byte, len(vals))
+	for i, val := range vals {
+		k, err := b.GetKey(val)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = k
+	}
+	return ret, nil
 }
 
 func (b *BoltDB) GetVal(key []byte) (uint, error) {

--- a/kvs/bolt_test.go
+++ b/kvs/bolt_test.go
@@ -37,6 +37,12 @@ func TestBolt(t *testing.T) {
 		GetKey(b, t)
 	})
 
+	t.Run("TestGetKeys", func(t *testing.T) {
+		b := initBolt(t)
+		defer SetupWithTeardown(b, t)()
+		GetKeys(b, t)
+	})
+
 	t.Run("TestGetVal", func(t *testing.T) {
 		b := initBolt(t)
 		defer SetupWithTeardown(b, t)()

--- a/kvs/db.go
+++ b/kvs/db.go
@@ -22,6 +22,7 @@ import (
 
 type KVS interface {
 	GetKey(uint) ([]byte, error)
+	GetKeys([]uint) ([][]byte, error)
 	GetVal([]byte) (uint, error)
 	Set([]byte, uint) error
 	Delete([]byte) error

--- a/kvs/db_test.go
+++ b/kvs/db_test.go
@@ -96,6 +96,26 @@ func GetKey(db KVS, t *testing.T) {
 	}
 }
 
+func GetKeys(db KVS, t *testing.T) {
+	tests := []struct {
+		vals []uint
+		keys [][]byte
+	}{
+		{[]uint{1}, [][]byte{[]byte("foo")}},
+		{[]uint{1, 2}, [][]byte{[]byte("foo"), []byte("bar")}},
+		{[]uint{3, 4}, [][]byte{[]byte("hoge"), []byte("huga")}},
+	}
+	for _, tt := range tests {
+		keys, err := db.GetKeys(tt.vals)
+		if err != nil {
+			t.Errorf("Unexpected error: TestGetKeys(%v) %v", tt, err)
+		}
+		if !reflect.DeepEqual(tt.keys, keys) {
+			t.Errorf("TestGetKeys(%v): %v, wanted: %v", tt.vals, keys, tt.keys)
+		}
+	}
+}
+
 func GetVal(db KVS, t *testing.T) {
 	tests := []struct {
 		key []byte

--- a/kvs/golevel.go
+++ b/kvs/golevel.go
@@ -47,6 +47,7 @@ func (g *GoLevel) GetKey(val uint) ([]byte, error) {
 	return g.vk.Get(ToBytes(val), nil)
 }
 
+// GetKeys wraps multiple calls GetKey
 func (g *GoLevel) GetKeys(vals []uint) ([][]byte, error) {
 	ret := make([][]byte, len(vals))
 	for i, val := range vals {

--- a/kvs/golevel.go
+++ b/kvs/golevel.go
@@ -47,6 +47,18 @@ func (g *GoLevel) GetKey(val uint) ([]byte, error) {
 	return g.vk.Get(ToBytes(val), nil)
 }
 
+func (g *GoLevel) GetKeys(vals []uint) ([][]byte, error) {
+	ret := make([][]byte, len(vals))
+	for i, val := range vals {
+		k, err := g.GetKey(val)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = k
+	}
+	return ret, nil
+}
+
 func (g *GoLevel) GetVal(key []byte) (uint, error) {
 	val, err := g.kv.Get(key, nil)
 	if err != nil {

--- a/kvs/golevel_test.go
+++ b/kvs/golevel_test.go
@@ -42,6 +42,12 @@ func TestGoLevel(t *testing.T) {
 		GetKey(g, t)
 	})
 
+	t.Run("TestGetKeys", func(t *testing.T) {
+		g := initGoLevel(t)
+		defer SetupWithTeardown(g, t)()
+		GetKeys(g, t)
+	})
+
 	t.Run("TestGetVal", func(t *testing.T) {
 		g := initGoLevel(t)
 		defer SetupWithTeardown(g, t)()

--- a/kvs/redis.go
+++ b/kvs/redis.go
@@ -72,6 +72,7 @@ func (r *Redis) GetKey(val uint) ([]byte, error) {
 	return key.Bytes()
 }
 
+// GetKeys wraps multiple calls GetKey
 func (r *Redis) GetKeys(vals []uint) ([][]byte, error) {
 	strVals := make([]string, len(vals))
 	for i, v := range vals {

--- a/kvs/redis.go
+++ b/kvs/redis.go
@@ -85,7 +85,10 @@ func (r *Redis) GetKeys(vals []uint) ([][]byte, error) {
 	if _, err := pipe.Exec(); err != nil {
 		return nil, err
 	}
-	response := keys.Val()
+	response, err := keys.Result()
+	if err != nil {
+		return nil, err
+	}
 	byteKeys := make([][]byte, len(response))
 	for i, k := range response {
 		if xi, ok := k.(string); ok {

--- a/kvs/redis_test.go
+++ b/kvs/redis_test.go
@@ -37,6 +37,12 @@ func TestRedis(t *testing.T) {
 		GetKey(r, t)
 	})
 
+	t.Run("TestGetKeys", func(t *testing.T) {
+		r := initRedis(t)
+		defer SetupWithTeardown(r, t)()
+		GetKeys(r, t)
+	})
+
 	t.Run("TestGetVal", func(t *testing.T) {
 		r := initRedis(t)
 		defer SetupWithTeardown(r, t)()

--- a/kvs/sql.go
+++ b/kvs/sql.go
@@ -49,6 +49,7 @@ func (s *SQL) GetKey(val uint) ([]byte, error) {
 	return []byte(key), nil
 }
 
+// GetKeys wraps multiple calls GetKey
 func (s *SQL) GetKeys(vals []uint) ([][]byte, error) {
 	ret := make([][]byte, len(vals))
 	for i, val := range vals {

--- a/kvs/sql.go
+++ b/kvs/sql.go
@@ -49,6 +49,18 @@ func (s *SQL) GetKey(val uint) ([]byte, error) {
 	return []byte(key), nil
 }
 
+func (s *SQL) GetKeys(vals []uint) ([][]byte, error) {
+	ret := make([][]byte, len(vals))
+	for i, val := range vals {
+		k, err := s.GetKey(val)
+		if err != nil {
+			return nil, err
+		}
+		ret[i] = k
+	}
+	return ret, nil
+}
+
 func (s *SQL) GetVal(key []byte) (uint, error) {
 	stmt, err := s.db.Prepare("select val from kvs where key = ? limit 1")
 	if err != nil {

--- a/kvs/sql_test.go
+++ b/kvs/sql_test.go
@@ -44,6 +44,12 @@ func TestSQL(t *testing.T) {
 		GetKey(s, t)
 	})
 
+	t.Run("TestGetKeys", func(t *testing.T) {
+		s := initSQL(t)
+		defer SetupWithTeardown(s, t)()
+		GetKeys(s, t)
+	})
+
 	t.Run("TestGetVal", func(t *testing.T) {
 		s := initSQL(t)
 		defer SetupWithTeardown(s, t)()

--- a/service/service.go
+++ b/service/service.go
@@ -73,13 +73,20 @@ func (s *Service) Search(vector []float64, size int, epsilon float32) ([]SearchR
 		return nil, err
 	}
 
-	ret := make([]SearchResult, len(result))
+	vals := make([]uint, len(result))
 	for i, v := range result {
-		id, err := s.db.GetKey(uint(v.ID))
+		vals[i] = uint(v.ID)
+	}
+	ids, err := s.db.GetKeys(vals)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]SearchResult, len(result))
+	for i, id := range ids {
 		ret[i] = SearchResult{
 			Id:       id,
-			Distance: v.Distance,
-			Error:    err,
+			Distance: result[i].Distance,
+			Error:    nil,
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
NOTE: this patch only affects when using redis as db.

Change multiple accesses to single read.
As a result, search latency is half or less than before when search size=26.
