### PR TITLE
Add GetObjects API

### DIFF
--- a/handler/http.go
+++ b/handler/http.go
@@ -306,9 +306,9 @@ func GetObjects(w http.ResponseWriter, r *http.Request) {
 	results := make([]model.GetObjectResult, 0, len(reqBody.IDs))
 	errs := make([]string, 0, len(reqBody.IDs))
 	for _, id := range reqBody.IDs {
-		result, err1 := service.GetObject(*(*[]byte)(unsafe.Pointer(&id)))
-		if err1 != nil {
-			errs = append(errs, fmt.Sprint(err1))
+		result, err := service.GetObject(*(*[]byte)(unsafe.Pointer(&id)))
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("Error: GetObject(%v) caused %v", id, err))
 		} else {
 			results = append(results, model.GetObjectResult{
 				ID:     *(*string)(unsafe.Pointer(&result.Id)),

--- a/handler/http.go
+++ b/handler/http.go
@@ -308,7 +308,7 @@ func GetObjects(w http.ResponseWriter, r *http.Request) {
 	for _, id := range reqBody.IDs {
 		result, err := service.GetObject(*(*[]byte)(unsafe.Pointer(&id)))
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("Error: GetObject(%v) caused %v", id, err))
+			errs = append(errs, fmt.Sprintf("Error: GetObject(%s) caused %s", id, err.Error()))
 		} else {
 			results = append(results, model.GetObjectResult{
 				ID:     *(*string)(unsafe.Pointer(&result.Id)),

--- a/handler/http_test.go
+++ b/handler/http_test.go
@@ -294,21 +294,21 @@ func TestHTTP(t *testing.T) {
 			want []model.GetObjectResult
 		}{
 			{[]string{"a"}, []model.GetObjectResult{
-				model.GetObjectResult{ID: "a", Vector: []float64{1, 0, 0, 0, 0, 0}}}},
+				model.GetObjectResult{ID: "a", Vector: []float32{1, 0, 0, 0, 0, 0}}}},
 
 			{[]string{"a", "b"}, []model.GetObjectResult{
-				model.GetObjectResult{ID: "a", Vector: []float64{1, 0, 0, 0, 0, 0}},
-				model.GetObjectResult{ID: "b", Vector: []float64{0, 1, 0, 0, 0, 0}}}},
+				model.GetObjectResult{ID: "a", Vector: []float32{1, 0, 0, 0, 0, 0}},
+				model.GetObjectResult{ID: "b", Vector: []float32{0, 1, 0, 0, 0, 0}}}},
 
 			{[]string{"c", "d", "e", "f"}, []model.GetObjectResult{
-				model.GetObjectResult{ID: "c", Vector: []float64{0, 0, 1, 0, 0, 0}},
-				model.GetObjectResult{ID: "d", Vector: []float64{0, 0, 0, 1, 0, 0}},
-				model.GetObjectResult{ID: "e", Vector: []float64{0, 0, 0, 0, 1, 0}},
-				model.GetObjectResult{ID: "f", Vector: []float64{0, 0, 0, 0, 0, 1}}}},
+				model.GetObjectResult{ID: "c", Vector: []float32{0, 0, 1, 0, 0, 0}},
+				model.GetObjectResult{ID: "d", Vector: []float32{0, 0, 0, 1, 0, 0}},
+				model.GetObjectResult{ID: "e", Vector: []float32{0, 0, 0, 0, 1, 0}},
+				model.GetObjectResult{ID: "f", Vector: []float32{0, 0, 0, 0, 0, 1}}}},
 
 			{[]string{"a", "g", "c"}, []model.GetObjectResult{
-				model.GetObjectResult{ID: "a", Vector: []float64{1, 0, 0, 0, 0, 0}},
-				model.GetObjectResult{ID: "c", Vector: []float64{0, 0, 1, 0, 0, 0}}}},
+				model.GetObjectResult{ID: "a", Vector: []float32{1, 0, 0, 0, 0, 0}},
+				model.GetObjectResult{ID: "c", Vector: []float32{0, 0, 1, 0, 0, 0}}}},
 		}
 
 		for _, tt := range tests {

--- a/model/model.go
+++ b/model/model.go
@@ -64,6 +64,20 @@ type MultiRemoveResponse struct {
 	Errors []error `json:"errors"`
 }
 
+type GetObjectsRequest struct {
+	IDs []string `json:"ids"`
+}
+
+type GetObjectResult struct {
+	ID     string    `json:"id"`
+	Vector []float64 `json:"vector"`
+}
+
+type GetObjectsResponse struct {
+	Result []GetObjectResult `json:"result"`
+	Errors []string          `json:"errors"`
+}
+
 type ErrorResponse struct {
 	Code    int    `json:"code"`
 	Error   error  `json:"error"`

--- a/model/model.go
+++ b/model/model.go
@@ -70,7 +70,7 @@ type GetObjectsRequest struct {
 
 type GetObjectResult struct {
 	ID     string    `json:"id"`
-	Vector []float64 `json:"vector"`
+	Vector []float32 `json:"vector"`
 }
 
 type GetObjectsResponse struct {

--- a/router/routes.go
+++ b/router/routes.go
@@ -97,4 +97,10 @@ var routes = []Route{
 		"/dimension",
 		handler.GetDimension,
 	},
+	Route{
+		"GetObjects",
+		http.MethodPost,
+		"/getobjects",
+		handler.GetObjects,
+	},
 }

--- a/service/service.go
+++ b/service/service.go
@@ -151,7 +151,7 @@ func (s *Service) GetObject(id []byte) (*GetObjectResult, error) {
 		return nil, err
 	}
 	if in <= 0 {
-		return nil, fmt.Errorf("Id(%s) is not in DB", id)
+		return nil, fmt.Errorf("Id(%s) is not in DB error", id)
 	}
 	vector, err := gongt.GetStrictVector(in)
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -157,13 +157,9 @@ func (s *Service) GetObject(id []byte) (*GetObjectResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	v := make([]float32, len(vector))
-	for i, e := range vector {
-		v[i] = float32(e)
-	}
 	ret := &GetObjectResult{
 		Id:     id,
-		Vector: v,
+		Vector: vector,
 	}
 	return ret, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -36,7 +36,7 @@ type SearchResult struct {
 
 type GetObjectResult struct {
 	Id     []byte
-	Vector []float64
+	Vector []float32
 }
 
 var (
@@ -157,9 +157,9 @@ func (s *Service) GetObject(id []byte) (*GetObjectResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	v := make([]float64, len(vector))
+	v := make([]float32, len(vector))
 	for i, e := range vector {
-		v[i] = float64(e)
+		v[i] = float32(e)
 	}
 	ret := &GetObjectResult{
 		Id:     id,

--- a/service/service.go
+++ b/service/service.go
@@ -17,6 +17,7 @@
 package service
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/yahoojapan/gongt"
@@ -31,6 +32,11 @@ type SearchResult struct {
 	Id       []byte
 	Distance float32
 	Error    error
+}
+
+type GetObjectResult struct {
+	Id     []byte
+	Vector []float64
 }
 
 var (
@@ -133,4 +139,31 @@ func (s *Service) Remove(id []byte) error {
 	}
 
 	return s.db.Delete(id)
+}
+
+func GetObject(id []byte) (*GetObjectResult, error) {
+	return s.GetObject(id)
+}
+
+func (s *Service) GetObject(id []byte) (*GetObjectResult, error) {
+	in, err := s.db.GetVal(id)
+	if err != nil {
+		return nil, err
+	}
+	if in <= 0 {
+		return nil, fmt.Errorf("Id(%s) is not in DB", id)
+	}
+	vector, err := gongt.GetStrictVector(in)
+	if err != nil {
+		return nil, err
+	}
+	v := make([]float64, len(vector))
+	for i, e := range vector {
+		v[i] = float64(e)
+	}
+	ret := &GetObjectResult{
+		Id:     id,
+		Vector: v,
+	}
+	return ret, nil
 }


### PR DESCRIPTION
Hi,
In my application, I need vectors itself.
NGT and gongt has getObject interface, So I add GetObjects API to NGTD.

- To avoid multiple http requests, I defined IDs to Vectors interface.
- Go's error type can not unmarshall to json. So I defined Errors as []string.

Would you like to check this Interface and patch is OK.
After that, I'll start to implement GRPC version.
