### PR TITLE
wait until redis finish load dump.rdb

### DIFF
--- a/cmd/ngtd/main.go
+++ b/cmd/ngtd/main.go
@@ -103,6 +103,11 @@ func main() {
 				Name:  "redis-database-index, I",
 				Usage: "list up 2 redis database indexes",
 			},
+			cli.IntFlag{
+				Name:  "redis-ping-max-retry",
+				Value: 60,
+				Usage: "wait until redis finish loading dump.rdb 10 * redis-ping-max-retry[sec].",
+			},
 		}
 
 		return append(commonFlags, f...)
@@ -116,7 +121,11 @@ func main() {
 			if len(indexes) == 0 {
 				indexes = cli.IntSlice{0, 1}
 			}
-			return kvs.NewRedis(c.String("redis-host"), c.String("redis-port"), c.String("redis-password"), indexes[0], indexes[1])
+			pingMaxRetry := c.Int("redis-ping-max-retry")
+			if pingMaxRetry <= 0 {
+				return nil, fmt.Errorf("invalid value: redis-ping-max-retry should be greater than 0: %d", pingMaxRetry)
+			}
+			return kvs.NewRedis(c.String("redis-host"), c.String("redis-port"), c.String("redis-password"), indexes[0], indexes[1], pingMaxRetry)
 		case "bolt":
 			return kvs.NewBoltDB(p)
 		case "golevel":

--- a/cmd/ngtd/main.go
+++ b/cmd/ngtd/main.go
@@ -22,6 +22,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/kpango/glg"
 	_ "github.com/mattn/go-sqlite3"
@@ -104,9 +105,14 @@ func main() {
 				Usage: "list up 2 redis database indexes",
 			},
 			cli.IntFlag{
-				Name:  "redis-ping-max-retry",
-				Value: 60,
-				Usage: "wait until redis finish loading dump.rdb 10 * redis-ping-max-retry[sec].",
+				Name:  "redis-ping-timeout",
+				Value: 600,
+				Usage: "wait until redis finish loading dump.rdb or timeout. (unit=second)",
+			},
+			cli.IntFlag{
+				Name:  "redis-ping-retry-freq",
+				Value: 10,
+				Usage: "try ping this frequency. (unit=second)",
 			},
 		}
 
@@ -121,11 +127,15 @@ func main() {
 			if len(indexes) == 0 {
 				indexes = cli.IntSlice{0, 1}
 			}
-			pingMaxRetry := c.Int("redis-ping-max-retry")
-			if pingMaxRetry <= 0 {
-				return nil, fmt.Errorf("invalid value: redis-ping-max-retry should be greater than 0: %d", pingMaxRetry)
+			pingTimeout := c.Int("redis-ping-timeout")
+			if pingTimeout <= 0 {
+				return nil, fmt.Errorf("invalid value: redis-ping-timeout should be greater than 0: %d", pingTimeout)
 			}
-			return kvs.NewRedis(c.String("redis-host"), c.String("redis-port"), c.String("redis-password"), indexes[0], indexes[1], pingMaxRetry)
+			pingRetryFreq := c.Int("redis-ping-retry-freq")
+			if pingRetryFreq <= 0 {
+				return nil, fmt.Errorf("invalid value: redis-ping-retry-freq should be greater than 0: %d", pingRetryFreq)
+			}
+			return kvs.NewRedis(c.String("redis-host"), c.String("redis-port"), c.String("redis-password"), indexes[0], indexes[1], pingTimeout*time.Second, pingRetryFreq*time.Second)
 		case "bolt":
 			return kvs.NewBoltDB(p)
 		case "golevel":

--- a/kvs/redis.go
+++ b/kvs/redis.go
@@ -57,6 +57,7 @@ func loopPing(client *redis.Client, numRetry int) error {
 	return err
 }
 
+// NewRedis initializes Redis
 func NewRedis(host, port, pass string, kv, vk int, pingMaxRetry int) (*Redis, error) {
 	if kv == vk {
 		return nil, fmt.Errorf("kv and vk must be defferent. (%d, %d)", kv, vk)

--- a/kvs/redis_test.go
+++ b/kvs/redis_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func initRedis(t *testing.T) *Redis {
-	r, err := NewRedis("127.0.0.1", "6379", "", 0, 1)
+	pingMaxRetry := 1
+	r, err := NewRedis("127.0.0.1", "6379", "", 0, 1, pingMaxRetry)
 	if err != nil {
 		t.Fatalf("Unexpected Error: initRedis(): %v", err)
 	}


### PR DESCRIPTION
Hi,
I deploy NGTD as stateless application with redis as db.
It means I create NGT Index and Redis dump.rdb at first.
Then copy dump.rdb to another server's /data directory and start redis-server. (and NGT Index too)

If dump.rdb is large, redis-server consumes 5~10 minutes to load data on memory.
While loading data, redis can not return PONG, and it cause error at [NewRedis](https://github.com/yahoojapan/ngtd/blob/master/kvs/redis.go#L54)

So I  added busy loop for redis ping-pong.

It blocks NGTD's db independent initialization steps.
But to care about faster initialization makes code complex.
And In stateful case (I think it is main use case), such optimization makes no sense.